### PR TITLE
xattr_get did not allocate a large enough buffer

### DIFF
--- a/xattr.c
+++ b/xattr.c
@@ -376,6 +376,10 @@ xattr_get(PyObject *self, PyObject *args, PyObject *keywds)
         goto freetgt;
     }
 
+    /* nalloc is the size of the attribute need to allocate enough for
+     * the null termination as well */
+    nalloc++;
+
     /* Try to allocate the memory, using Python's allocator */
     if((buf = PyMem_Malloc(nalloc)) == NULL) {
         res = PyErr_NoMemory();


### PR DESCRIPTION
the getxattr library call requires a size option for the length of the
buffer. We only allocated enough memory to handle the exact length of
the value of the extended attribute. You must allocate an extra byte for
the null terminator on the end of the string.

#$ getfattr -n ceph.dir.rbytes /var/cephfs/test
ceph.dir.rbytes="222142325238"

current head:
>>> xattr.get('/var/cephfs/test', 'ceph.dir.rbytes')
b'22214232523\x00'

with my fix:
>>> xattr.get('/var/cephfs/test', 'ceph.dir.rbytes')
b'222142325238'