### PR TITLE
Added support for OS X's slightly different xattr calls.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 
 import distutils
+import platform
 try:
   from setuptools import setup, Extension
 except ImportError:
@@ -12,6 +13,9 @@ of the attr C library - see attr(5)."""
 version = "0.5.6"
 author = "Iustin Pop"
 author_email = "iustin@k1024.org"
+libraries = []
+if platform.system() == 'Linux':
+    libraries.append("attr")
 macros = [
     ("_XATTR_VERSION", '"%s"' % version),
     ("_XATTR_AUTHOR", '"%s"' % author),
@@ -27,7 +31,7 @@ setup(name = "pyxattr",
       download_url = "http://pyxattr.k1024.org/downloads/",
       license = "LGPL",
       ext_modules = [Extension("xattr", ["xattr.c"],
-                               libraries=["attr"],
+                               libraries=libraries,
                                define_macros=macros,
                                extra_compile_args=["-Wall", "-Werror", "-Wsign-compare"],
                                )],

--- a/test/test_xattr.py
+++ b/test/test_xattr.py
@@ -109,9 +109,9 @@ class xattrTest(unittest.TestCase):
             xattr.setxattr(item, self.USER_ATTR, self.USER_VAL, 0, symlink)
         except IOError:
             err = sys.exc_info()[1]
-            if err.errno == errno.EPERM and symlink:
+            if symlink and (err.errno == errno.EPERM or err.errno == errno.ENOENT):
                 # symlinks may fail, in which case we abort the rest
-                # of the test for this case
+                # of the test for this case (Linux returns EPERM; OS X returns ENOENT)
                 return
             raise
         self.assertRaises(EnvironmentError, xattr.setxattr, item,
@@ -146,9 +146,9 @@ class xattrTest(unittest.TestCase):
                           nofollow=symlink)
         except IOError:
             err = sys.exc_info()[1]
-            if err.errno == errno.EPERM and symlink:
+            if symlink and (err.errno == errno.EPERM or err.errno == errno.ENOENT):
                 # symlinks may fail, in which case we abort the rest
-                # of the test for this case
+                # of the test for this case (Linux returns EPERM; OS X returns ENOENT)
                 return
             raise
         self.assertRaises(EnvironmentError, xattr.set, item,


### PR DESCRIPTION
I added some minor indirection around the base `(foo)xattr` C calls so that I could create functions with the Linux signature that call the OS X versions.

Note this does't handle the half-dozen OS X special cases (com.apple.ResourceFork, com.apple.FinderInfo, compressed EAs, etc.) but the API is low-level enough that it shouldn't matter in most cases (and if it does matter to someone, that's what ctypes/cffi is for).