### PR TITLE
CI: Run doc builds too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,10 @@ jobs:
           # This path is specific to Ubuntu
           path: ~/.cache/pip
           # Look to see if there is a cache hit for the corresponding requirements file
-          key: v1-pip-${{ runner.os }}-${{ matrix.python-version }}
+          key: v2-pip-${{ runner.os }}-${{ matrix.python-version }}
           restore-keys: |
-            v1-pip-${{ runner.os }}
-            v1-pip-
+            v2-pip-${{ runner.os }}
+            v2-pip-
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
           pip install pytest
           pip install codecov
           pip install sphinx
+          pip install recommonmark
 
       - name: Install typing for old Python
         run: pip install typing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
         run: |
           pip install pytest
           pip install codecov
+          pip install sphinx
 
       - name: Install typing for old Python
         run: pip install typing
@@ -94,3 +95,6 @@ jobs:
         with:
           name: code-coverage-${{ matrix.os }}-${{ matrix.python-version }}
           path: codecov-report.txt
+
+      - name: Build documentation
+        run: make doc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,10 +60,6 @@ jobs:
           pip install sphinx
           pip install recommonmark
 
-      - name: Install typing for old Python
-        run: pip install typing
-        if: matrix.installTyping
-
       - name: Build the code
         run: python ./setup.py build_ext -i
 


### PR DESCRIPTION
This would better live in a separate CI run, since we don't care so much about all OS builds, but let's how much it adds.