### PR TITLE
Restrict MacOS builds to fewer Python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-14]
+        os: [ubuntu-22.04]
         python-version:
           - '3.7'
           - '3.8'
@@ -38,6 +38,16 @@ jobs:
           - 'pypy-3.8'
           - 'pypy-3.9-nightly'
           - 'pypy-3.10-nightly'
+        include:
+            # Python < 3.10 is not available on macOS 14
+            - os: macos-14
+              python-version: '3.10'
+            - os: macos-14
+              python-version: '3.11'
+            - os: macos-14  
+              python-version: '3.12'
+            - os: macos-14
+              python-version: 'pypy-3.8'
       fail-fast: false
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,8 @@ jobs:
           - 'pypy-3.7'
           - 'pypy-3.8'
           - 'pypy-3.9-nightly'
-          - 'pypy-3.10-nightly'
+          # Pypy-3.10 nightly seems to have some issues in bootstrapping
+          # - 'pypy-3.10-nightly'
         include:
             # Python < 3.10 is not available on macOS 14
             - os: macos-14


### PR DESCRIPTION
Per https://github.com/iustin/pyxattr/actions/runs/7778373717, not all versions are available on MacOS 14, so restrict to a smaller set. I don't think that extensive (across Python versions) on MacOS brings much, if the base Linux job does that.