### PR TITLE
Re-enable pypy-3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,8 @@ jobs:
           - '3.12'
           - 'pypy-3.7'
           - 'pypy-3.8'
-          - 'pypy-3.9-nightly'
-          # Pypy-3.10 nightly seems to have some issues in bootstrapping
-          # - 'pypy-3.10-nightly'
+          - 'pypy-3.9'
+          - 'pypy-3.10'
         include:
             # Python < 3.10 is not available on macOS 14
             - os: macos-14
@@ -49,6 +48,10 @@ jobs:
               python-version: '3.12'
             - os: macos-14
               python-version: 'pypy-3.8'
+            - os: macos-14
+              python-version: 'pypy-3.9'
+            - os: macos-14
+              python-version: 'pypy-3.10'
       fail-fast: false
 
     steps:


### PR DESCRIPTION
Based on #41, this can be re-enabled now.